### PR TITLE
refactor: move tests to test module

### DIFF
--- a/adapters/driven/persistence/inmemory/api_test.go
+++ b/adapters/driven/persistence/inmemory/api_test.go
@@ -1,12 +1,14 @@
-package inmemory
+package inmemory_test
 
 import (
-	"github.com/quii/go-fakes-and-contracts/domain/planner"
 	"testing"
+
+	"github.com/quii/go-fakes-and-contracts/adapters/driven/persistence/inmemory"
+	"github.com/quii/go-fakes-and-contracts/domain/planner"
 )
 
 func TestInmemoryAPI1(t *testing.T) {
 	planner.API1Contract{NewAPI1: func() planner.API1 {
-		return NewAPI1()
+		return inmemory.NewAPI1()
 	}}.Test(t)
 }

--- a/adapters/driven/persistence/inmemory/calendar_store_test.go
+++ b/adapters/driven/persistence/inmemory/calendar_store_test.go
@@ -1,14 +1,16 @@
-package inmemory
+package inmemory_test
 
 import (
-	"github.com/quii/go-fakes-and-contracts/domain/planner"
 	"testing"
+
+	"github.com/quii/go-fakes-and-contracts/adapters/driven/persistence/inmemory"
+	"github.com/quii/go-fakes-and-contracts/domain/planner"
 )
 
 func TestInMemoryCalendar(t *testing.T) {
 	planner.CalendarContract{
 		NewCalendar: func() planner.Calendar {
-			return NewCalendar()
+			return inmemory.NewCalendar()
 		},
 	}.Test(t)
 }

--- a/adapters/driven/persistence/inmemory/recipe_store_test.go
+++ b/adapters/driven/persistence/inmemory/recipe_store_test.go
@@ -1,12 +1,14 @@
-package inmemory
+package inmemory_test
 
 import (
-	"github.com/quii/go-fakes-and-contracts/domain/planner"
 	"testing"
+
+	"github.com/quii/go-fakes-and-contracts/adapters/driven/persistence/inmemory"
+	"github.com/quii/go-fakes-and-contracts/domain/planner"
 )
 
 func TestInMemoryRecipeStore(t *testing.T) {
 	planner.RecipeBookContract{NewBook: func() planner.RecipeBook {
-		return NewRecipeStore()
+		return inmemory.NewRecipeStore()
 	}}.Test(t)
 }


### PR DESCRIPTION
Just a minor best practise suggestion to use `_test` modules for all tests. There is no need to access anything internal here.